### PR TITLE
fixed problem with encoding running tests with ruby 2

### DIFF
--- a/spec/yell/adapters/gelf_spec.rb
+++ b/spec/yell/adapters/gelf_spec.rb
@@ -88,7 +88,7 @@ describe Yell::Adapters::Gelf do
       end
 
       it "should be zipped" do
-        datagrams[0][0..1].should == "\x78\x9c" # zlib header
+        datagrams[0][0..1].bytes.should == [0x78, 0x9C] # zlib header
       end
     end
 


### PR DESCRIPTION
This solve a issue I found trying to run the tests with ruby 2.
the string returned by the datagram has a different encoding from the expected result.

Checking the header bytes as an array will mitigate this problem.

cheers.
