### PR TITLE
Failing Travis build - use new Rubinius syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ rvm:
   - 1.9.3
   - jruby-18mode
   - jruby-19mode
-  - rbx-18mode
-  # - rbx-19mode
+  - rbx-2
   - ree
 
 notifications:


### PR DESCRIPTION
rbx is only now available through `rbx-2`
http://docs.travis-ci.com/user/languages/ruby/
